### PR TITLE
fix: harden I2C, DMA, and PDM

### DIFF
--- a/examples/hpm6750evkmini/src/bin/i2c_oled.rs
+++ b/examples/hpm6750evkmini/src/bin/i2c_oled.rs
@@ -1,0 +1,294 @@
+//! I2C OLED (SSD1306) Example for HPM6750EVKMINI
+//!
+//! Drives a 128x64 SSD1306 OLED display via I2C0.
+//!
+//! I2C0 pins:
+//!   SCL = PB11
+//!   SDA = PB10
+//!
+//! LED = PB19 (active low)
+
+#![no_main]
+#![no_std]
+
+use embedded_graphics::mono_font::ascii::FONT_10X20;
+use embedded_graphics::mono_font::MonoTextStyle;
+use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics::prelude::*;
+use embedded_graphics::text::{Alignment, Text};
+use embedded_hal::delay::DelayNs;
+use hal::gpio::{Level, Output, Speed};
+use hal::i2c::I2c;
+use hal::mode::Blocking;
+use riscv::delay::McycleDelay;
+use {defmt_rtt as _, hpm_hal as hal, panic_halt as _};
+
+pub mod consts {
+    pub const PRIMARY_ADDRESS: u8 = 0x3C;
+}
+
+pub mod cmds {
+    pub const MEMORYMODE: u8 = 0x20;
+    pub const COLUMNADDR: u8 = 0x21;
+    pub const PAGEADDR: u8 = 0x22;
+    pub const SETCONTRAST: u8 = 0x81;
+    pub const CHARGEPUMP: u8 = 0x8D;
+    pub const SEGREMAP: u8 = 0xA0;
+    pub const DISPLAYALLON_RESUME: u8 = 0xA4;
+    pub const NORMALDISPLAY: u8 = 0xA6;
+    pub const SETMULTIPLEX: u8 = 0xA8;
+    pub const DISPLAYOFF: u8 = 0xAE;
+    pub const DISPLAYON: u8 = 0xAF;
+    pub const COMSCANDEC: u8 = 0xC8;
+    pub const SETDISPLAYOFFSET: u8 = 0xD3;
+    pub const SETDISPLAYCLOCKDIV: u8 = 0xD5;
+    pub const SETPRECHARGE: u8 = 0xD9;
+    pub const SETCOMPINS: u8 = 0xDA;
+    pub const SETVCOMDETECT: u8 = 0xDB;
+    pub const SETLOWCOLUMN: u8 = 0x00;
+    pub const SETSTARTLINE: u8 = 0x40;
+    pub const DEACTIVATE_SCROLL: u8 = 0x2E;
+}
+
+pub struct SSD1306 {
+    i2c: I2c<'static, Blocking>,
+    addr: u8,
+}
+
+pub const WIDTH: usize = 128;
+pub const HEIGHT: usize = 64;
+pub const PAGES: usize = HEIGHT / 8;
+
+impl SSD1306 {
+    pub fn new(i2c: I2c<'static, Blocking>, addr: u8) -> Self {
+        Self { i2c, addr }
+    }
+
+    pub fn init(&mut self) {
+        use cmds::*;
+
+        const INIT1: &[u8] = &[
+            DISPLAYOFF,
+            SETDISPLAYCLOCKDIV,
+            0x80,
+            SETMULTIPLEX,
+        ];
+        self.send_commands(INIT1);
+        self.send_command(SETLOWCOLUMN | ((HEIGHT as u8) - 1));
+
+        const INIT2: &[u8] = &[
+            SETDISPLAYOFFSET,
+            0x0,
+            SETSTARTLINE | 0x0,
+            CHARGEPUMP,
+        ];
+        self.send_commands(INIT2);
+        self.send_command(0x14); // internal VCC
+
+        const INIT3: &[u8] = &[
+            MEMORYMODE,
+            0x00,
+            SEGREMAP | 0x1,
+            COMSCANDEC,
+        ];
+        self.send_commands(INIT3);
+
+        self.send_commands(&[SETCOMPINS, 0x12]); // 128x64
+        self.send_commands(&[SETCONTRAST, 0xCF]);
+        self.send_command(SETPRECHARGE);
+        self.send_command(0xF1); // internal VCC
+
+        const INIT5: &[u8] = &[
+            SETVCOMDETECT,
+            0x40,
+            DISPLAYALLON_RESUME,
+            NORMALDISPLAY,
+            DEACTIVATE_SCROLL,
+            DISPLAYON,
+        ];
+        self.send_commands(INIT5);
+    }
+
+    #[inline]
+    fn send_command(&mut self, c: u8) {
+        self.i2c.blocking_write(self.addr, &[0x00, c]).unwrap();
+    }
+    #[inline]
+    fn send_commands(&mut self, cmds: &[u8]) {
+        for &c in cmds {
+            self.send_command(c);
+        }
+    }
+    #[inline]
+    fn send_data(&mut self, d: u8) {
+        self.i2c.blocking_write(self.addr, &[0x40, d]).unwrap();
+    }
+
+    pub fn display_fb(&mut self, fb: &[u8]) {
+        self.send_commands(&[cmds::PAGEADDR, 0, 0xff]);
+        self.send_commands(&[cmds::COLUMNADDR, 0, (WIDTH as u8 - 1)]);
+
+        for page in 0..PAGES {
+            for i in 0..WIDTH {
+                self.send_data(fb[page * WIDTH + i]);
+            }
+        }
+    }
+}
+
+pub struct Framebuffer([u8; WIDTH * PAGES]);
+
+impl Framebuffer {
+    pub fn new() -> Self {
+        Self([0; WIDTH * PAGES])
+    }
+
+    pub fn data(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+
+    pub fn set_pixel(&mut self, x: i16, y: i16, color: bool) {
+        if x >= (WIDTH as i16) || y >= (HEIGHT as i16) || x < 0 || y < 0 {
+            return;
+        }
+        let x = x as u8;
+        let y = y as u8;
+        let page = y / 8;
+        let bit = y % 8;
+        let mask = 1 << bit;
+        let idx = (page as usize) * WIDTH + x as usize;
+        if color {
+            self.0[idx] |= mask;
+        } else {
+            self.0[idx] &= !mask;
+        }
+    }
+}
+
+impl OriginDimensions for Framebuffer {
+    fn size(&self) -> Size {
+        Size::new(WIDTH as _, HEIGHT as _)
+    }
+}
+
+impl DrawTarget for Framebuffer {
+    type Color = BinaryColor;
+    type Error = core::convert::Infallible;
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for Pixel(point, color) in pixels.into_iter() {
+            self.set_pixel(point.x as i16, point.y as i16, color.is_on());
+        }
+        Ok(())
+    }
+}
+
+pub struct Rand;
+
+impl Rand {
+    pub fn next(&self) -> u8 {
+        static mut SEED: u8 = 0xaa;
+        unsafe {
+            let mut lfsr = SEED;
+            let bit = (lfsr >> 0) ^ (lfsr >> 2) ^ (lfsr >> 3) ^ (lfsr >> 5);
+            lfsr = (lfsr >> 1) | (bit << 7);
+            SEED = lfsr;
+            lfsr
+        }
+    }
+}
+
+pub struct World {
+    points: [Point; 10],
+}
+
+impl World {
+    pub fn new() -> Self {
+        World {
+            points: [
+                Point::new(3, 10),
+                Point::new(10, 1),
+                Point::new(20, 5),
+                Point::new(30, 2),
+                Point::new(95, 10),
+                Point::new(100, 2),
+                Point::new(110, 10),
+                Point::new(120, 20),
+                Point::new(97, 30),
+                Point::new(89, 32),
+            ],
+        }
+    }
+
+    pub fn tick(&mut self) {
+        for p in self.points.iter_mut() {
+            p.x -= 1;
+            p.y += 1;
+            if p.x >= (128 + 32) || p.y >= (64 + 10) || p.y == 0 || p.x == 0 {
+                p.x = (Rand.next() % (128 + 32)) as _;
+                p.y = 0;
+            }
+        }
+    }
+
+    pub fn draw(&self, fb: &mut Framebuffer) {
+        for p in self.points.iter() {
+            let x = p.x as i16;
+            let y = p.y as i16;
+            fb.set_pixel(x - 1, y, true);
+            fb.set_pixel(x, y - 1, true);
+            fb.set_pixel(x + 1, y, true);
+            fb.set_pixel(x, y + 1, true);
+            for i in 2..10 {
+                fb.set_pixel(x + i, y - i, true);
+            }
+        }
+    }
+}
+
+#[hal::entry]
+fn main() -> ! {
+    let p = hal::init(Default::default());
+
+    let mut delay = McycleDelay::new(hal::sysctl::clocks().cpu0.0);
+
+    defmt::info!("I2C OLED Example - HPM6750EVKMINI");
+    defmt::info!("CPU0: {}Hz", hal::sysctl::clocks().cpu0.0);
+
+    let mut i2c_config = hal::i2c::Config::default();
+    i2c_config.mode = hal::i2c::I2cMode::FastPlus;
+
+    let i2c = hal::i2c::I2c::new_blocking(p.I2C0, p.PB11, p.PB10, i2c_config);
+
+    let mut screen = SSD1306::new(i2c, consts::PRIMARY_ADDRESS);
+    screen.init();
+    defmt::info!("SSD1306 initialized");
+
+    let mut led = Output::new(p.PB19, Level::Low, Speed::default());
+
+    let mut fb = Framebuffer::new();
+    fb.clear(BinaryColor::Off).unwrap();
+    screen.display_fb(fb.data());
+
+    let mut world = World::new();
+    let character_style = MonoTextStyle::new(&FONT_10X20, BinaryColor::On);
+
+    loop {
+        world.tick();
+        world.draw(&mut fb);
+
+        Text::with_alignment("Rust", Point::new(0, 14), character_style, Alignment::Left)
+            .draw(&mut fb)
+            .unwrap();
+
+        screen.display_fb(fb.data());
+
+        fb.clear(BinaryColor::Off).unwrap();
+
+        led.toggle();
+        delay.delay_us(1000);
+    }
+}

--- a/examples/hpm6750evkmini/src/bin/i2c_oled.rs
+++ b/examples/hpm6750evkmini/src/bin/i2c_oled.rs
@@ -74,7 +74,7 @@ impl SSD1306 {
             SETMULTIPLEX,
         ];
         self.send_commands(INIT1);
-        self.send_command(SETLOWCOLUMN | ((HEIGHT as u8) - 1));
+        self.send_command((HEIGHT as u8) - 1);
 
         const INIT2: &[u8] = &[
             SETDISPLAYOFFSET,
@@ -259,7 +259,7 @@ fn main() -> ! {
     defmt::info!("CPU0: {}Hz", hal::sysctl::clocks().cpu0.0);
 
     let mut i2c_config = hal::i2c::Config::default();
-    i2c_config.mode = hal::i2c::I2cMode::FastPlus;
+    i2c_config.mode = hal::i2c::I2cMode::Fast;
 
     let i2c = hal::i2c::I2c::new_blocking(p.I2C0, p.PB11, p.PB10, i2c_config);
 

--- a/examples/hpm6750evkmini/src/bin/i2c_oled_async.rs
+++ b/examples/hpm6750evkmini/src/bin/i2c_oled_async.rs
@@ -1,0 +1,283 @@
+//! I2C OLED (SSD1306) Async Example for HPM6750EVKMINI
+//!
+//! Same animation as `i2c_oled.rs` but using async I2C with DMA.
+//!
+//! I2C0 pins:
+//!   SCL = PB11
+//!   SDA = PB10
+//!
+//! LED = PB19 (active low)
+
+#![no_main]
+#![no_std]
+#![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
+#![feature(abi_riscv_interrupt)]
+
+use defmt::info;
+use embedded_graphics::mono_font::ascii::FONT_10X20;
+use embedded_graphics::mono_font::MonoTextStyle;
+use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics::prelude::*;
+use embedded_graphics::text::{Alignment, Text};
+use embassy_time::Timer;
+use hal::gpio::{Level, Output, Speed};
+use hal::i2c::I2c;
+use hal::mode::Async;
+use hal::peripherals;
+use hpm_hal as hal;
+use hpm_hal::bind_interrupts;
+use {defmt_rtt as _, panic_halt as _};
+
+bind_interrupts!(struct Irqs {
+    I2C0 => hal::i2c::InterruptHandler<peripherals::I2C0>;
+});
+
+pub const ADDR: u8 = 0x3C;
+
+pub mod cmds {
+    pub const MEMORYMODE: u8 = 0x20;
+    pub const COLUMNADDR: u8 = 0x21;
+    pub const PAGEADDR: u8 = 0x22;
+    pub const SETCONTRAST: u8 = 0x81;
+    pub const CHARGEPUMP: u8 = 0x8D;
+    pub const SEGREMAP: u8 = 0xA0;
+    pub const DISPLAYALLON_RESUME: u8 = 0xA4;
+    pub const NORMALDISPLAY: u8 = 0xA6;
+    pub const SETMULTIPLEX: u8 = 0xA8;
+    pub const DISPLAYOFF: u8 = 0xAE;
+    pub const DISPLAYON: u8 = 0xAF;
+    pub const COMSCANDEC: u8 = 0xC8;
+    pub const SETDISPLAYOFFSET: u8 = 0xD3;
+    pub const SETDISPLAYCLOCKDIV: u8 = 0xD5;
+    pub const SETPRECHARGE: u8 = 0xD9;
+    pub const SETCOMPINS: u8 = 0xDA;
+    pub const SETVCOMDETECT: u8 = 0xDB;
+    pub const SETLOWCOLUMN: u8 = 0x00;
+    pub const SETSTARTLINE: u8 = 0x40;
+    pub const DEACTIVATE_SCROLL: u8 = 0x2E;
+}
+
+pub const WIDTH: usize = 128;
+pub const HEIGHT: usize = 64;
+pub const PAGES: usize = HEIGHT / 8;
+
+pub struct SSD1306 {
+    i2c: I2c<'static, Async>,
+    addr: u8,
+}
+
+impl SSD1306 {
+    pub fn new(i2c: I2c<'static, Async>, addr: u8) -> Self {
+        Self { i2c, addr }
+    }
+
+    pub async fn init(&mut self) {
+        use cmds::*;
+
+        for &c in &[
+            DISPLAYOFF, SETDISPLAYCLOCKDIV, 0x80, SETMULTIPLEX,
+        ] {
+            self.cmd(c).await;
+        }
+        self.cmd(SETLOWCOLUMN | ((HEIGHT as u8) - 1)).await;
+
+        for &c in &[SETDISPLAYOFFSET, 0x0, SETSTARTLINE | 0x0, CHARGEPUMP] {
+            self.cmd(c).await;
+        }
+        self.cmd(0x14).await; // internal VCC
+
+        for &c in &[MEMORYMODE, 0x00, SEGREMAP | 0x1, COMSCANDEC] {
+            self.cmd(c).await;
+        }
+
+        for &c in &[SETCOMPINS, 0x12] {
+            self.cmd(c).await;
+        }
+        for &c in &[SETCONTRAST, 0xCF] {
+            self.cmd(c).await;
+        }
+        self.cmd(SETPRECHARGE).await;
+        self.cmd(0xF1).await;
+
+        for &c in &[
+            SETVCOMDETECT, 0x40, DISPLAYALLON_RESUME, NORMALDISPLAY,
+            DEACTIVATE_SCROLL, DISPLAYON,
+        ] {
+            self.cmd(c).await;
+        }
+    }
+
+    #[inline]
+    async fn cmd(&mut self, c: u8) {
+        self.i2c.write(self.addr, &[0x00, c]).await.unwrap();
+    }
+
+    pub async fn display_fb(&mut self, fb: &[u8]) {
+        // Set page and column range
+        self.cmd(cmds::PAGEADDR).await;
+        self.cmd(0).await;
+        self.cmd(0xFF).await;
+        self.cmd(cmds::COLUMNADDR).await;
+        self.cmd(0).await;
+        self.cmd(WIDTH as u8 - 1).await;
+
+        // Send framebuffer in 32-byte chunks via DMA
+        let mut buf = [0u8; 33]; // 1 control byte + 32 data
+        buf[0] = 0x40;
+        for chunk in fb.chunks(32) {
+            buf[1..1 + chunk.len()].copy_from_slice(chunk);
+            self.i2c.write(self.addr, &buf[..1 + chunk.len()]).await.unwrap();
+        }
+    }
+}
+
+pub struct Framebuffer([u8; WIDTH * PAGES]);
+
+impl Framebuffer {
+    pub fn new() -> Self {
+        Self([0; WIDTH * PAGES])
+    }
+
+    pub fn data(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub fn set_pixel(&mut self, x: i16, y: i16, color: bool) {
+        if x >= (WIDTH as i16) || y >= (HEIGHT as i16) || x < 0 || y < 0 {
+            return;
+        }
+        let idx = (y as usize >> 3) * WIDTH + x as usize;
+        let mask = 1 << (y as u8 & 7);
+        if color {
+            self.0[idx] |= mask;
+        } else {
+            self.0[idx] &= !mask;
+        }
+    }
+}
+
+impl OriginDimensions for Framebuffer {
+    fn size(&self) -> Size {
+        Size::new(WIDTH as _, HEIGHT as _)
+    }
+}
+
+impl DrawTarget for Framebuffer {
+    type Color = BinaryColor;
+    type Error = core::convert::Infallible;
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = Pixel<Self::Color>>,
+    {
+        for Pixel(point, color) in pixels {
+            self.set_pixel(point.x as i16, point.y as i16, color.is_on());
+        }
+        Ok(())
+    }
+}
+
+pub struct Rand;
+
+impl Rand {
+    pub fn next(&self) -> u8 {
+        static mut SEED: u8 = 0xaa;
+        unsafe {
+            let mut lfsr = SEED;
+            let bit = (lfsr >> 0) ^ (lfsr >> 2) ^ (lfsr >> 3) ^ (lfsr >> 5);
+            lfsr = (lfsr >> 1) | (bit << 7);
+            SEED = lfsr;
+            lfsr
+        }
+    }
+}
+
+pub struct World {
+    points: [Point; 10],
+}
+
+impl World {
+    pub fn new() -> Self {
+        World {
+            points: [
+                Point::new(3, 10),
+                Point::new(10, 1),
+                Point::new(20, 5),
+                Point::new(30, 2),
+                Point::new(95, 10),
+                Point::new(100, 2),
+                Point::new(110, 10),
+                Point::new(120, 20),
+                Point::new(97, 30),
+                Point::new(89, 32),
+            ],
+        }
+    }
+
+    pub fn tick(&mut self) {
+        for p in self.points.iter_mut() {
+            p.x -= 1;
+            p.y += 1;
+            if p.x >= (128 + 32) || p.y >= (64 + 10) || p.y == 0 || p.x == 0 {
+                p.x = (Rand.next() % (128 + 32)) as _;
+                p.y = 0;
+            }
+        }
+    }
+
+    pub fn draw(&self, fb: &mut Framebuffer) {
+        for p in self.points.iter() {
+            let x = p.x as i16;
+            let y = p.y as i16;
+            fb.set_pixel(x - 1, y, true);
+            fb.set_pixel(x, y - 1, true);
+            fb.set_pixel(x + 1, y, true);
+            fb.set_pixel(x, y + 1, true);
+            for i in 2..10 {
+                fb.set_pixel(x + i, y - i, true);
+            }
+        }
+    }
+}
+
+#[embassy_executor::main(entry = "hpm_hal::entry")]
+async fn main(_spawner: embassy_executor::Spawner) -> ! {
+    let p = hal::init(Default::default());
+
+    info!("I2C OLED Async Example - HPM6750EVKMINI");
+
+    let mut i2c_config = hal::i2c::Config::default();
+    i2c_config.mode = hal::i2c::I2cMode::FastPlus;
+
+    let i2c = I2c::new(p.I2C0, p.PB11, p.PB10, Irqs, p.HDMA_CH0, i2c_config);
+
+    let mut screen = SSD1306::new(i2c, ADDR);
+    screen.init().await;
+    info!("SSD1306 initialized (async)");
+
+    let mut led = Output::new(p.PB19, Level::Low, Speed::default());
+
+    let mut fb = Framebuffer::new();
+    fb.clear(BinaryColor::Off).unwrap();
+    screen.display_fb(fb.data()).await;
+
+    let mut world = World::new();
+    let character_style = MonoTextStyle::new(&FONT_10X20, BinaryColor::On);
+
+    loop {
+        world.tick();
+        world.draw(&mut fb);
+
+        Text::with_alignment("Rust", Point::new(0, 14), character_style, Alignment::Left)
+            .draw(&mut fb)
+            .unwrap();
+
+        screen.display_fb(fb.data()).await;
+
+        fb.clear(BinaryColor::Off).unwrap();
+
+        led.toggle();
+        Timer::after_micros(1000).await;
+    }
+}

--- a/examples/hpm6750evkmini/src/bin/i2c_oled_async.rs
+++ b/examples/hpm6750evkmini/src/bin/i2c_oled_async.rs
@@ -10,7 +10,6 @@
 
 #![no_main]
 #![no_std]
-#![feature(type_alias_impl_trait)]
 #![feature(impl_trait_in_assoc_type)]
 #![feature(abi_riscv_interrupt)]
 
@@ -80,7 +79,7 @@ impl SSD1306 {
         ] {
             self.cmd(c).await;
         }
-        self.cmd(SETLOWCOLUMN | ((HEIGHT as u8) - 1)).await;
+        self.cmd((HEIGHT as u8) - 1).await;
 
         for &c in &[SETDISPLAYOFFSET, 0x0, SETSTARTLINE | 0x0, CHARGEPUMP] {
             self.cmd(c).await;
@@ -248,7 +247,7 @@ async fn main(_spawner: embassy_executor::Spawner) -> ! {
     info!("I2C OLED Async Example - HPM6750EVKMINI");
 
     let mut i2c_config = hal::i2c::Config::default();
-    i2c_config.mode = hal::i2c::I2cMode::FastPlus;
+    i2c_config.mode = hal::i2c::I2cMode::Fast;
 
     let i2c = I2c::new(p.I2C0, p.PB11, p.PB10, Irqs, p.HDMA_CH0, i2c_config);
 

--- a/src/dma/dmamux.rs
+++ b/src/dma/dmamux.rs
@@ -3,27 +3,9 @@
 use crate::pac;
 
 pub(crate) fn configure_dmamux(mux_num: usize, request: u8) {
-    defmt::info!("configure_dmamux: ch={}, request={}", mux_num, request);
-
-    // Print DMAMUX base address and register address
-    let dmamux_base = pac::DMAMUX.as_ptr() as u32;
     let ch_mux_regs = pac::DMAMUX.muxcfg(mux_num);
-    let reg_addr = ch_mux_regs.as_ptr() as u32;
-    defmt::info!("  DMAMUX base=0x{:08x}, muxcfg[{}] addr=0x{:08x}", dmamux_base, mux_num, reg_addr);
-
-    // Read before write
-    let before = ch_mux_regs.read();
-    defmt::info!("  before: raw=0x{:08x}, enable={}, source={}", before.0, before.enable(), before.source());
-
-    // Write the value
-    let write_val = (1u32 << 31) | (request as u32);
-    defmt::info!("  writing: 0x{:08x}", write_val);
     ch_mux_regs.write(|reg| {
         reg.set_enable(true);
-        reg.set_source(request); // peripheral request number
+        reg.set_source(request);
     });
-
-    // Verify
-    let readback = ch_mux_regs.read();
-    defmt::info!("  after: raw=0x{:08x}, enable={}, source={}", readback.0, readback.enable(), readback.source());
 }

--- a/src/dma/v1.rs
+++ b/src/dma/v1.rs
@@ -109,7 +109,7 @@ impl ChannelState {
 pub(crate) unsafe fn init(cs: critical_section::CriticalSection) {
     use crate::interrupt;
 
-    // Note: HDMA/XDMA clock resources are already added to group 0 in sysctl::init_clock()
+    // Note: HDMA/XDMA clock resources must be added to group 0 in sysctl::init_clock()
 
     pac::HDMA.dmactrl().modify(|w| w.set_reset(true));
 
@@ -154,7 +154,13 @@ unsafe fn dma_on_irq(r: pac::dma::Dma, mux_num_base: u32) {
     // - bit width alignment error
     // DMA error: this is normally a hardware error(memory alignment or access), but we can't do anything about it
     if err != 0 {
-        panic!("DMA: error on DMA@{:08x}, errsts=0b{:08b}", r.as_ptr() as u32, err);
+        panic!(
+            "DMA: error on DMA@{:08x}, errsts=0b{:08b}, tc=0b{:08b}, abort=0b{:08b}",
+            r.as_ptr() as u32,
+            err,
+            tc,
+            abort
+        );
     }
 
     if tc != 0 {
@@ -227,7 +233,6 @@ impl AnyChannel {
 
         let r = info.dma.regs();
         let ch = info.num; // channel number in current dma controller
-        let mux_ch = info.mux_num; // channel number in dma mux, (XDMA_CH0 = HDMA_CH7+1 = 8)
 
         // follow the impl of dma_setup_channel
 
@@ -278,10 +283,13 @@ impl AnyChannel {
             w.set_srcaddrctrl(src_addr_ctrl);
             w.set_dstaddrctrl(dst_addr_ctrl);
 
+            // srcreqsel/dstreqsel use the channel number within the DMA controller (0-7),
+            // NOT the DMAMUX output number. For HDMA they happen to be the same,
+            // but for XDMA ch=0 while mux_num=8. HPM SDK uses ch_num here.
             if dir == Dir::MemoryToPeripheralType {
-                w.set_dstreqsel(mux_ch as u8);
+                w.set_dstreqsel(ch as u8);
             } else {
-                w.set_srcreqsel(mux_ch as u8);
+                w.set_srcreqsel(ch as u8);
             }
             // unmask interrupts
             w.set_inttcmask(!options.complete_transfer_irq);
@@ -698,56 +706,12 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
         // Configure DMAMUX
         super::dmamux::configure_dmamux(mux_ch, request);
 
-        // Build ctrl register value for circular RX
-        let ctrl = {
-            let mut val = 0u32;
-            // Source: peripheral, fixed address, handshake mode
-            val |= (vals::Mode::HANDSHAKE.to_bits() as u32) << 24; // srcmode
-            val |= (AddrCtrl::FIXED.to_bits() as u32) << 14; // srcaddrctrl
-            val |= (data_size.width() as u32) << 8; // srcwidth
-
-            // Destination: memory, increment address, normal mode
-            val |= (vals::Mode::NORMAL.to_bits() as u32) << 26; // dstmode
-            val |= (AddrCtrl::INCREMENT.to_bits() as u32) << 16; // dstaddrctrl
-            val |= (data_size.width() as u32) << 11; // dstwidth
-
-            // Request select
-            val |= (mux_ch as u32) << 20; // srcreqsel
-
-            // Burst size (default 1)
-            val |= 0 << 4; // srcburstsize
-
-            // Enable interrupts for ring buffer tracking
-            // TC interrupt enabled (mask = 0)
-
-            // Enable bit will be set when starting
-            val |= 1; // enable
-
-            val
-        };
-
-        // Setup linked descriptor pointing to itself for circular operation
-        let desc_addr = descriptor as *mut _ as u32;
-
-        #[cfg(hpm67)]
-        let desc_addr = core_local_mem_to_sys_address(0, desc_addr);
-
-        descriptor.ctrl = ctrl;
-        descriptor.trans_size = len as u32;
-        descriptor.src_addr = src_addr;
-        descriptor.src_addr_high = 0;
-        descriptor.dst_addr = dst_addr;
-        descriptor.dst_addr_high = 0;
-        descriptor.linked_ptr = desc_addr; // Point to self for circular
-        descriptor.linked_ptr_high = 0;
-
         // Configure channel registers
         let ch_cr = r.chctrl(ch);
 
         ch_cr.src_addr().write_value(src_addr);
         ch_cr.dst_addr().write_value(dst_addr);
         ch_cr.tran_size().modify(|w| w.0 = len as u32);
-        ch_cr.llpointer().modify(|w| w.0 = desc_addr); // Link to descriptor
 
         // Clear interrupts
         r.int_status().write(|w| {
@@ -768,12 +732,36 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
             w.set_dstmode(vals::Mode::NORMAL);
             w.set_srcaddrctrl(AddrCtrl::FIXED);
             w.set_dstaddrctrl(AddrCtrl::INCREMENT);
-            w.set_srcreqsel(mux_ch as u8);
+            // Use channel number within DMA controller (not DMAMUX number)
+            // HPM SDK: SRCREQSEL_SET(ch_num), where ch_num is 0-7 per controller
+            w.set_srcreqsel(ch as u8);
             w.set_inttcmask(false); // Enable TC interrupt
             w.set_interrmask(false);
             w.set_intabtmask(true);
             w.set_enable(false);
         });
+
+        // Read back the channel configuration, then enable descriptor reload.
+        let mut ctrl = ch_cr.ctrl().read();
+        ctrl.set_enable(true);
+
+        // Setup linked descriptor pointing to itself for circular operation
+        let desc_addr = descriptor as *mut _ as u32;
+
+        #[cfg(hpm67)]
+        let desc_addr = core_local_mem_to_sys_address(0, desc_addr);
+
+        descriptor.ctrl = ctrl.0;
+        descriptor.trans_size = len as u32;
+        descriptor.src_addr = src_addr;
+        descriptor.src_addr_high = 0;
+        descriptor.dst_addr = dst_addr;
+        descriptor.dst_addr_high = 0;
+        descriptor.linked_ptr = desc_addr; // Point to self for circular
+        descriptor.linked_ptr_high = 0;
+
+        // Set linked list pointer in channel register
+        ch_cr.llpointer().modify(|w| w.0 = desc_addr);
 
         Self {
             channel,

--- a/src/i2c/mod.rs
+++ b/src/i2c/mod.rs
@@ -137,38 +137,28 @@ pub struct I2c<'d, M: Mode> {
     _phantom: PhantomData<M>,
 }
 
-impl<'d> I2c<'d, Blocking> {
-    /// Create a new blocking I2C driver.
-    pub fn new_blocking<T: Instance>(
-        peri: Peri<'d, T>,
-        scl: Peri<'d, impl SclPin<T>>,
-        sda: Peri<'d, impl SdaPin<T>>,
-        config: Config,
-    ) -> Self {
-        scl.set_as_ioc_gpio();
-        sda.set_as_ioc_gpio();
+/// Common initialization for I2C constructors: bus recovery, pin config, clock setup.
+fn init_i2c_pins<T: Instance>(scl: &Peri<'_, impl SclPin<T>>, sda: &Peri<'_, impl SdaPin<T>>) {
+    scl.set_as_ioc_gpio();
+    sda.set_as_ioc_gpio();
 
-        #[cfg(not(ip_feature_i2c_support_reset))]
-        loop {
-            // TODO: Fix this strangle control flow
-            use embedded_hal::delay::DelayNs;
-            use riscv::delay::McycleDelay;
+    // For chips without hardware I2C reset, try to recover bus by bit-banging SCL
+    // when SDA is stuck low (per I2C spec Section 3.1.16).
+    #[cfg(not(ip_feature_i2c_support_reset))]
+    {
+        use embedded_hal::delay::DelayNs;
+        scl.set_as_input();
+        sda.set_as_input();
 
-            scl.set_as_input();
-            sda.set_as_input();
+        if !scl.is_high() {
+            panic!("SCL is low, cannot recover I2C bus");
+        }
 
-            if !scl.is_high() {
-                panic!("SCL is low, panic");
-            }
+        if !sda.is_high() {
+            #[cfg(feature = "defmt")]
+            defmt::info!("I2C: SDA is stuck low, attempting bus recovery");
 
-            if !sda.is_high() {
-                #[cfg(feature = "defmt")]
-                defmt::info!("SDA is low, reset bus");
-            } else {
-                break;
-            }
-
-            let mut delay = McycleDelay::new(crate::sysctl::clocks().cpu0.0);
+            let mut delay = riscv::delay::McycleDelay::new(crate::sysctl::clocks().cpu0.0);
             scl.set_as_output();
             for _ in 0..3 {
                 for _ in 0..9 {
@@ -179,35 +169,38 @@ impl<'d> I2c<'d, Blocking> {
                 }
                 delay.delay_ms(100);
             }
-            break;
         }
+    }
 
-        // ALT, Open Drain, Pull-up
-        scl.ioc_pad().func_ctl().write(|w| {
-            w.set_alt_select(scl.alt_num());
+    // Configure pins: ALT function, open-drain, pull-up, loop-back
+    for (pad, alt) in [(scl.ioc_pad(), scl.alt_num()), (sda.ioc_pad(), sda.alt_num())] {
+        pad.func_ctl().write(|w| {
+            w.set_alt_select(alt);
             w.set_loop_back(true);
         });
-        scl.ioc_pad().pad_ctl().write(|w| {
+        pad.pad_ctl().write(|w| {
             w.set_od(true);
             w.set_pe(true);
             w.set_ps(true);
         });
-        sda.ioc_pad().func_ctl().write(|w| {
-            w.set_alt_select(sda.alt_num());
-            w.set_loop_back(true);
-        });
-        sda.ioc_pad().pad_ctl().write(|w| {
-            w.set_od(true);
-            w.set_pe(true);
-            w.set_ps(true);
-        });
+    }
 
-        T::add_resource_group(0);
-        {
-            use crate::sysctl::*;
-            T::set_clock(ClockConfig::new(ClockMux::CLK_24M, 1));
-        }
+    T::add_resource_group(0);
+    {
+        use crate::sysctl::*;
+        T::set_clock(ClockConfig::new(ClockMux::CLK_24M, 1));
+    }
+}
 
+impl<'d> I2c<'d, Blocking> {
+    /// Create a new blocking I2C driver.
+    pub fn new_blocking<T: Instance>(
+        peri: Peri<'d, T>,
+        scl: Peri<'d, impl SclPin<T>>,
+        sda: Peri<'d, impl SdaPin<T>>,
+        config: Config,
+    ) -> Self {
+        init_i2c_pins::<T>(&scl, &sda);
         Self::new_inner(peri, Some(scl.into()), Some(sda.into()), None, config)
     }
 }
@@ -222,68 +215,7 @@ impl<'d> I2c<'d, Async> {
         dma: Peri<'d, impl I2cDma<T>>,
         config: Config,
     ) -> Self {
-        scl.set_as_ioc_gpio();
-        sda.set_as_ioc_gpio();
-
-        #[cfg(not(ip_feature_i2c_support_reset))]
-        loop {
-            // TODO: Fix this strangle control flow
-            use embedded_hal::delay::DelayNs;
-            use riscv::delay::McycleDelay;
-
-            scl.set_as_input();
-            sda.set_as_input();
-
-            if !scl.is_high() {
-                panic!("SCL is low, panic");
-            }
-
-            if !sda.is_high() {
-                #[cfg(feature = "defmt")]
-                defmt::info!("SDA is low, reset bus");
-            } else {
-                break;
-            }
-
-            let mut delay = McycleDelay::new(crate::sysctl::clocks().cpu0.0);
-            scl.set_as_output();
-            for _ in 0..3 {
-                for _ in 0..9 {
-                    scl.set_high();
-                    delay.delay_ms(10);
-                    scl.set_low();
-                    delay.delay_ms(10);
-                }
-                delay.delay_ms(100);
-            }
-            break;
-        }
-
-        scl.ioc_pad().func_ctl().write(|w| {
-            w.set_alt_select(scl.alt_num());
-            w.set_loop_back(true);
-        });
-        scl.ioc_pad().pad_ctl().write(|w| {
-            w.set_od(true);
-            w.set_pe(true);
-            w.set_ps(true);
-        });
-        sda.ioc_pad().func_ctl().write(|w| {
-            w.set_alt_select(sda.alt_num());
-            w.set_loop_back(true);
-        });
-        sda.ioc_pad().pad_ctl().write(|w| {
-            w.set_od(true);
-            w.set_pe(true);
-            w.set_ps(true);
-        });
-
-        T::add_resource_group(0);
-        {
-            use crate::sysctl::*;
-            T::set_clock(ClockConfig::new(ClockMux::CLK_24M, 1));
-        }
-
+        init_i2c_pins::<T>(&scl, &sda);
         Self::new_inner(peri, Some(scl.into()), Some(sda.into()), new_dma!(dma), config)
     }
 
@@ -571,93 +503,8 @@ impl<'d, M: Mode> I2c<'d, M> {
     }
 
     /// Blocking write, restart, read.
-    pub fn blocking_write_read(&mut self, addr: u8, reg: &[u8], read: &mut [u8]) -> Result<(), Error> {
-        if reg.is_empty()
-            || reg.len() > I2C_SOC_TRANSFER_COUNT_MAX
-            || read.is_empty()
-            || read.len() > I2C_SOC_TRANSFER_COUNT_MAX
-        {
-            return Err(Error::InvalidArgument);
-        }
-
-        let r = self.info.regs;
-        let timeout = self.timeout();
-
-        while r.status().read().busbusy() {
-            self.timeout().check()?;
-        }
-
-        // W1C, clear CMPL bit to avoid blocking the transmission
-        r.status().write(|w| w.set_cmpl(true));
-
-        r.cmd().write(|w| w.set_cmd(vals::Cmd::CLEAR_FIFO));
-        r.ctrl().write(|w| {
-            w.set_phase_start(true);
-            w.set_phase_addr(true);
-            w.set_phase_data(true);
-            w.set_dir(vals::Dir::MASTER_WRITE_SLAVE_READ);
-            #[cfg(ip_feature_i2c_transfer_count_max_4096)]
-            w.set_datacnt_high((reg.len() >> 8) as _);
-            w.set_datacnt(reg.len() as _);
-        });
-
-        r.addr().modify(|w| w.set_addr(addr as u16));
-
-        for b in reg {
-            r.data().write(|w| w.set_data(*b));
-        }
-        r.cmd().write(|w| w.set_cmd(vals::Cmd::DATA_TRANSACTION));
-
-        // Before starting to transmit data, judge addrhit to ensure that the slave address exists on the bus.
-        while !r.status().read().addrhit() {
-            if timeout.check().is_err() {
-                // the address misses, a stop needs to be added to prevent the bus from being busy.
-                r.status().write(|w| w.set_cmpl(true));
-                r.ctrl().write(|w| w.set_phase_stop(true));
-                r.cmd().write(|w| w.set_cmd(vals::Cmd::DATA_TRANSACTION));
-
-                return Err(Error::NoAddrHit);
-            }
-        }
-
-        r.status().write(|w| w.set_addrhit(true));
-
-        while !r.status().read().cmpl() {
-            timeout.check()?;
-        }
-
-        // W1C, clear CMPL bit to avoid blocking the transmission
-        r.status().write(|w| w.set_cmpl(true));
-
-        r.cmd().write(|w| w.set_cmd(vals::Cmd::CLEAR_FIFO));
-        r.ctrl().write(|w| {
-            w.set_phase_start(true);
-            w.set_phase_stop(true);
-            w.set_phase_addr(true);
-            w.set_phase_data(true);
-            w.set_dir(vals::Dir::MASTER_READ_SLAVE_WRITE);
-            #[cfg(ip_feature_i2c_transfer_count_max_4096)]
-            w.set_datacnt_high((read.len() >> 8) as _);
-            w.set_datacnt(read.len() as _);
-        });
-        r.cmd().write(|w| w.set_cmd(vals::Cmd::DATA_TRANSACTION));
-
-        for b in read {
-            loop {
-                if !r.status().read().fifoempty() {
-                    *b = r.data().read().data();
-                    break;
-                } else {
-                    timeout.check()?;
-                }
-            }
-        }
-
-        while !r.status().read().cmpl() {
-            timeout.check()?;
-        }
-
-        Ok(())
+    pub fn blocking_write_read(&mut self, addr: u8, write: &[u8], read: &mut [u8]) -> Result<(), Error> {
+        self.blocking_transaction(addr, &mut [Operation::Write(write), Operation::Read(read)])
     }
 
     fn blocking_do_operation_timeout(
@@ -752,7 +599,6 @@ impl<'d, M: Mode> I2c<'d, M> {
         Ok(())
     }
 
-    // i2c_master_write
     fn blocking_read_timeout(&mut self, addr: u8, read: &mut [u8], timeout: Timeout) -> Result<(), Error> {
         self.blocking_do_operation_timeout(
             addr,
@@ -766,7 +612,6 @@ impl<'d, M: Mode> I2c<'d, M> {
         )
     }
 
-    // i2c_master_write
     fn blocking_write_timeout(
         &mut self,
         addr: u8,

--- a/src/i2c/mod.rs
+++ b/src/i2c/mod.rs
@@ -84,7 +84,7 @@ pub enum Error {
     /// Bus error
     Bus,
     /// Bus busy
-    BusyBusy,
+    BusBusy,
     /// Arbitration lost
     Arbitration,
     /// ACK not received (either to the address or to a data byte)
@@ -96,7 +96,7 @@ pub enum Error {
     /// Zero-length transfers are not allowed.
     ZeroLengthTransfer,
     /// Not completed
-    TrasnmitNotCompleted,
+    TransmitNotCompleted,
     /// No address hit
     NoAddrHit,
     /// Invalid argument
@@ -341,6 +341,7 @@ impl<'d> I2c<'d, Async> {
 
     async fn do_operation_inner(&mut self, addr: u8, op: &mut Operation<'_>, frame: FrameOptions) -> Result<(), Error> {
         let r = self.info.regs;
+        let timeout = self.timeout();
 
         let (size, dir) = match op {
             Operation::Read(read) => (read.len(), vals::Dir::MASTER_READ_SLAVE_WRITE),
@@ -389,6 +390,24 @@ impl<'d> I2c<'d, Async> {
 
         r.setup().modify(|w| w.set_dmaen(true));
         r.cmd().write(|w| w.set_cmd(vals::Cmd::DATA_TRANSACTION));
+
+        // Wait for address hit before DMA proceeds (blocking poll, same as C SDK).
+        // addrhit arrives within a few SCL cycles (~microseconds), so brief spin is fine.
+        loop {
+            if r.status().read().addrhit() {
+                break;
+            }
+            if timeout.check().is_err() {
+                // Address miss: send STOP to release the bus.
+                r.status().write(|w| w.set_cmpl(true));
+                r.ctrl().write(|w| w.set_phase_stop(true));
+                r.cmd().write(|w| w.set_cmd(vals::Cmd::DATA_TRANSACTION));
+                r.setup().modify(|w| w.set_dmaen(false));
+                drop(on_drop);
+                return Err(Error::NoAddrHit);
+            }
+        }
+        r.status().write(|w| w.set_addrhit(true));
 
         transfer.await;
 
@@ -477,19 +496,17 @@ impl<'d, M: Mode> I2c<'d, M> {
             w.set_master(true);
         });
 
-        if r.status().read().linescl() == false {
-            #[cfg(feature = "defmt")]
-            defmt::info!("CLK is low, panic");
-            loop {}
+        if !r.status().read().linescl() {
+            panic!("I2C: SCL is stuck low after init");
         }
 
         #[cfg(ip_feature_i2c_support_reset)]
-        if r.status().read().linesda() == false {
+        if !r.status().read().linesda() {
             use embedded_hal::delay::DelayNs;
             use riscv::delay::McycleDelay;
 
             // SDA is low, reset bus
-            // i2s_gen_reset_signal
+            // i2c_gen_reset_signal
             // generate SCL clock as reset signal
             r.ctrl().modify(|w| {
                 w.set_reset_len(9);
@@ -548,11 +565,19 @@ impl<'d, M: Mode> I2c<'d, M> {
         });
         r.cmd().write(|w| w.set_cmd(vals::Cmd::DATA_TRANSACTION));
 
-        // Before starting to transmit data, judge addrhit to ensure that the slave address exists on the bus.
-        while !r.status().read().addrhit() {
-            timeout.check()?;
+        // Wait for address hit to ensure the slave address exists on the bus.
+        loop {
+            if r.status().read().addrhit() {
+                break;
+            }
+            if timeout.check().is_err() {
+                // Address miss: send STOP to prevent the bus from staying busy.
+                r.status().write(|w| w.set_cmpl(true));
+                r.ctrl().write(|w| w.set_phase_stop(true));
+                r.cmd().write(|w| w.set_cmd(vals::Cmd::DATA_TRANSACTION));
+                return Err(Error::NoAddrHit);
+            }
         }
-
         r.status().write(|w| w.set_addrhit(true));
 
         // when size is zero, it's probe slave device, so directly return success
@@ -560,43 +585,54 @@ impl<'d, M: Mode> I2c<'d, M> {
             return Ok(());
         }
 
-        match op {
-            Operation::Read(read) => {
-                for b in read.iter_mut() {
-                    loop {
-                        if !r.status().read().fifoempty() {
-                            *b = r.data().read().data();
-                            break;
-                        } else {
-                            timeout.check()?;
+        let result = (|| {
+            match op {
+                Operation::Read(read) => {
+                    for b in read.iter_mut() {
+                        loop {
+                            if !r.status().read().fifoempty() {
+                                *b = r.data().read().data();
+                                break;
+                            } else {
+                                timeout.check()?;
+                            }
+                        }
+                    }
+                }
+                Operation::Write(write) => {
+                    for b in write.iter() {
+                        loop {
+                            if !r.status().read().fifofull() {
+                                r.data().write(|w| w.set_data(*b));
+                                break;
+                            } else {
+                                timeout.check()?;
+                            }
                         }
                     }
                 }
             }
-            Operation::Write(write) => {
-                for b in write.iter() {
-                    loop {
-                        if !r.status().read().fifofull() {
-                            r.data().write(|w| w.set_data(*b));
-                            break;
-                        } else {
-                            timeout.check()?;
-                        }
-                    }
-                }
+
+            // wait completion
+            while !r.status().read().cmpl() {
+                timeout.check()?;
             }
+
+            if get_data_count(r) > 0 && size > 0 {
+                return Err(Error::TransmitNotCompleted);
+            }
+
+            Ok(())
+        })();
+
+        if result.is_err() {
+            // Abort and send STOP to release the bus on any data transfer error.
+            r.status().write(|w| w.set_cmpl(true));
+            r.ctrl().write(|w| w.set_phase_stop(true));
+            r.cmd().write(|w| w.set_cmd(vals::Cmd::DATA_TRANSACTION));
         }
 
-        // wait completion
-        while !r.status().read().cmpl() {
-            timeout.check()?;
-        }
-
-        if get_data_count(r) > 0 && size > 0 {
-            return Err(Error::TrasnmitNotCompleted);
-        }
-
-        Ok(())
+        result
     }
 
     fn blocking_read_timeout(&mut self, addr: u8, read: &mut [u8], timeout: Timeout) -> Result<(), Error> {
@@ -751,13 +787,13 @@ foreach_peripheral!(
 impl embedded_hal::i2c::Error for Error {
     fn kind(&self) -> embedded_hal::i2c::ErrorKind {
         match *self {
-            Self::Bus | Error::BusyBusy | Error::NoAddrHit => embedded_hal::i2c::ErrorKind::Bus,
+            Self::Bus | Error::BusBusy | Error::NoAddrHit => embedded_hal::i2c::ErrorKind::Bus,
             Self::Arbitration => embedded_hal::i2c::ErrorKind::ArbitrationLoss,
             Self::Nack => embedded_hal::i2c::ErrorKind::NoAcknowledge(embedded_hal::i2c::NoAcknowledgeSource::Unknown),
             Self::Timeout => embedded_hal::i2c::ErrorKind::Other,
             Self::Overrun => embedded_hal::i2c::ErrorKind::Overrun,
             Self::ZeroLengthTransfer => embedded_hal::i2c::ErrorKind::Other,
-            Self::TrasnmitNotCompleted => embedded_hal::i2c::ErrorKind::Other,
+            Self::TransmitNotCompleted => embedded_hal::i2c::ErrorKind::Other,
             Self::InvalidArgument => embedded_hal::i2c::ErrorKind::Other,
         }
     }

--- a/src/i2c/mod.rs
+++ b/src/i2c/mod.rs
@@ -234,6 +234,7 @@ impl<'d> I2c<'d, Async> {
                 send_start: true,
                 send_stop: true,
                 send_addr: true,
+                wait_bus_free: false,
             },
         )
         .await
@@ -254,6 +255,7 @@ impl<'d> I2c<'d, Async> {
                 send_start: true,
                 send_stop: true,
                 send_addr: true,
+                wait_bus_free: false,
             },
         )
         .await
@@ -280,6 +282,7 @@ impl<'d> I2c<'d, Async> {
                 send_start: true,
                 send_stop: false,
                 send_addr: true,
+                wait_bus_free: false,
             },
         )
         .await?;
@@ -290,6 +293,7 @@ impl<'d> I2c<'d, Async> {
                 send_start: true,
                 send_stop: true,
                 send_addr: true,
+                wait_bus_free: false,
             },
         )
         .await?;
@@ -351,6 +355,9 @@ impl<'d> I2c<'d, Async> {
         if size > I2C_SOC_TRANSFER_COUNT_MAX {
             return Err(Error::InvalidArgument);
         }
+        if size == 0 {
+            return Err(Error::ZeroLengthTransfer);
+        }
 
         // W1C, clear CMPL bit to avoid blocking the transmission
         r.status().write(|w| w.set_cmpl(true));
@@ -391,41 +398,56 @@ impl<'d> I2c<'d, Async> {
         r.setup().modify(|w| w.set_dmaen(true));
         r.cmd().write(|w| w.set_cmd(vals::Cmd::DATA_TRANSACTION));
 
-        // Wait for address hit before DMA proceeds (blocking poll, same as C SDK).
-        // addrhit arrives within a few SCL cycles (~microseconds), so brief spin is fine.
-        loop {
-            if r.status().read().addrhit() {
-                break;
+        if frame.send_addr {
+            // ADDRHIT has no interrupt source. Yield while polling so a missing device does not
+            // monopolize the executor until the timeout expires.
+            loop {
+                let status = r.status().read();
+                if status.addrhit() {
+                    break;
+                }
+                if status.arblose() {
+                    drop(on_drop);
+                    return Err(Error::Arbitration);
+                }
+                if timeout.check().is_err() {
+                    // Address miss: send STOP to release the bus.
+                    r.status().write(|w| w.set_cmpl(true));
+                    r.ctrl().write(|w| w.set_phase_stop(true));
+                    r.cmd().write(|w| w.set_cmd(vals::Cmd::DATA_TRANSACTION));
+                    drop(on_drop);
+                    return Err(Error::NoAddrHit);
+                }
+                embassy_futures::yield_now().await;
             }
-            if timeout.check().is_err() {
-                // Address miss: send STOP to release the bus.
-                r.status().write(|w| w.set_cmpl(true));
-                r.ctrl().write(|w| w.set_phase_stop(true));
-                r.cmd().write(|w| w.set_cmd(vals::Cmd::DATA_TRANSACTION));
-                r.setup().modify(|w| w.set_dmaen(false));
-                drop(on_drop);
-                return Err(Error::NoAddrHit);
-            }
+            r.status().write(|w| w.set_addrhit(true));
         }
-        r.status().write(|w| w.set_addrhit(true));
-
-        transfer.await;
 
         let s = self.state;
+        let transfer_and_complete = async move {
+            transfer.await;
 
-        let complete_or_error = poll_fn(move |cx| {
-            s.waker.register(cx.waker());
+            poll_fn(move |cx| {
+                s.waker.register(cx.waker());
 
-            if r.status().read().cmpl() {
-                return Poll::Ready(Ok(()));
-            } else if r.status().read().arblose() {
-                return Poll::Ready(Err(Error::Arbitration));
-            }
+                if r.status().read().cmpl() {
+                    Poll::Ready(Ok(()))
+                } else if r.status().read().arblose() {
+                    Poll::Ready(Err(Error::Arbitration))
+                } else {
+                    Poll::Pending
+                }
+            })
+            .await
+        };
 
-            Poll::Pending
-        });
+        let ret = timeout.with(transfer_and_complete).await;
 
-        let ret = complete_or_error.await;
+        if matches!(ret, Err(Error::Timeout)) {
+            r.status().write(|w| w.set_cmpl(true));
+            r.ctrl().write(|w| w.set_phase_stop(true));
+            r.cmd().write(|w| w.set_cmd(vals::Cmd::DATA_TRANSACTION));
+        }
 
         drop(on_drop);
 
@@ -541,8 +563,10 @@ impl<'d, M: Mode> I2c<'d, M> {
             return Err(Error::InvalidArgument);
         }
 
-        while r.status().read().busbusy() {
-            timeout.check()?;
+        if frame.wait_bus_free {
+            while r.status().read().busbusy() {
+                timeout.check()?;
+            }
         }
 
         // W1C, clear CMPL bit to avoid blocking the transmission
@@ -565,23 +589,28 @@ impl<'d, M: Mode> I2c<'d, M> {
         });
         r.cmd().write(|w| w.set_cmd(vals::Cmd::DATA_TRANSACTION));
 
-        // Wait for address hit to ensure the slave address exists on the bus.
-        loop {
-            if r.status().read().addrhit() {
-                break;
+        if frame.send_addr {
+            // Wait for address hit to ensure the slave address exists on the bus.
+            loop {
+                if r.status().read().addrhit() {
+                    break;
+                }
+                if timeout.check().is_err() {
+                    // Address miss: send STOP to prevent the bus from staying busy.
+                    r.status().write(|w| w.set_cmpl(true));
+                    r.ctrl().write(|w| w.set_phase_stop(true));
+                    r.cmd().write(|w| w.set_cmd(vals::Cmd::DATA_TRANSACTION));
+                    return Err(Error::NoAddrHit);
+                }
             }
-            if timeout.check().is_err() {
-                // Address miss: send STOP to prevent the bus from staying busy.
-                r.status().write(|w| w.set_cmpl(true));
-                r.ctrl().write(|w| w.set_phase_stop(true));
-                r.cmd().write(|w| w.set_cmd(vals::Cmd::DATA_TRANSACTION));
-                return Err(Error::NoAddrHit);
-            }
+            r.status().write(|w| w.set_addrhit(true));
         }
-        r.status().write(|w| w.set_addrhit(true));
 
-        // when size is zero, it's probe slave device, so directly return success
+        // An address-only transfer is used to probe a slave device.
         if size == 0 {
+            while !r.status().read().cmpl() {
+                timeout.check()?;
+            }
             return Ok(());
         }
 
@@ -644,6 +673,7 @@ impl<'d, M: Mode> I2c<'d, M> {
                 send_start: true,
                 send_stop: true,
                 send_addr: true,
+                wait_bus_free: true,
             },
         )
     }
@@ -663,6 +693,7 @@ impl<'d, M: Mode> I2c<'d, M> {
                 send_start: true,
                 send_stop,
                 send_addr: true,
+                wait_bus_free: true,
             },
         )
     }
@@ -856,6 +887,7 @@ struct FrameOptions {
     send_start: bool,
     send_stop: bool,
     send_addr: bool,
+    wait_bus_free: bool,
 }
 
 #[allow(dead_code)]
@@ -869,6 +901,7 @@ fn operation_frames<'a, 'b: 'a>(
     let mut operations = operations.iter_mut().peekable();
 
     let mut next_first_frame = true;
+    let mut first_operation = true;
 
     Ok(iter::from_fn(move || {
         let Some(op) = operations.next() else {
@@ -892,14 +925,19 @@ fn operation_frames<'a, 'b: 'a>(
         // because the resulting frame options are identical for write operations.
         #[rustfmt::skip]
         let frame = match (first_frame, next_op) {
-            (true, None) => FrameOptions { send_start: true, send_stop: true, send_addr: true },
-            (true, Some(Read(_))) => FrameOptions { send_start: true, send_stop: false, send_addr: true },
-            (true, Some(Write(_))) => FrameOptions { send_start: true, send_stop: false, send_addr: true },
+            (true, None) => FrameOptions { send_start: true, send_stop: true, send_addr: true, wait_bus_free: false },
+            (true, Some(Read(_))) => FrameOptions { send_start: true, send_stop: false, send_addr: true, wait_bus_free: false },
+            (true, Some(Write(_))) => FrameOptions { send_start: true, send_stop: false, send_addr: true, wait_bus_free: false },
             //
-            (false, None) => FrameOptions { send_start: false, send_stop: true, send_addr: false},
-            (false, Some(Read(_))) => FrameOptions { send_start: false, send_stop: false, send_addr: false },
-            (false, Some(Write(_))) => FrameOptions { send_start: false, send_stop: false, send_addr: false },
+            (false, None) => FrameOptions { send_start: false, send_stop: true, send_addr: false, wait_bus_free: false },
+            (false, Some(Read(_))) => FrameOptions { send_start: false, send_stop: false, send_addr: false, wait_bus_free: false },
+            (false, Some(Write(_))) => FrameOptions { send_start: false, send_stop: false, send_addr: false, wait_bus_free: false },
         };
+        let frame = FrameOptions {
+            wait_bus_free: first_operation && frame.send_start,
+            ..frame
+        };
+        first_operation = false;
 
         // Pre-calculate if `next_op` is the first operation of its type. We do this here and not at
         // the beginning of the loop because we hand out `op` as iterator value and cannot access it

--- a/src/pdm/mod.rs
+++ b/src/pdm/mod.rs
@@ -903,6 +903,10 @@ impl<'d, T: Instance> PdmDma<'d, T> {
 
         i2s.rxdslot(0).write(|w| w.set_en(config.channels.0 as u16));
 
+        // Set RX FIFO threshold for DMA request generation
+        // DMA request fires when FIFO filling >= threshold (C SDK default: 4)
+        i2s.fifo_thresh().modify(|w| w.set_rx(4));
+
         // Enable RX and RX DMA
         i2s.ctrl().modify(|w| {
             w.set_rx_en(1);
@@ -1140,6 +1144,10 @@ impl<'d, T: Instance> PdmDma<'d, T> {
         });
 
         i2s.rxdslot(0).write(|w| w.set_en(config.channels.0 as u16));
+
+        // Set RX FIFO threshold for DMA request generation
+        // DMA request fires when FIFO filling >= threshold (C SDK default: 4)
+        i2s.fifo_thresh().modify(|w| w.set_rx(4));
 
         // Enable RX and RX DMA
         i2s.ctrl().modify(|w| {

--- a/src/sysctl/v67.rs
+++ b/src/sysctl/v67.rs
@@ -223,6 +223,9 @@ pub(crate) unsafe fn init(config: Config) {
     clock_add_to_group(pac::resources::LMM0, 0);
     clock_add_to_group(pac::resources::LMM1, 0);
 
+    clock_add_to_group(pac::resources::DMA0, 0); // HDMA
+    clock_add_to_group(pac::resources::DMA1, 0); // XDMA
+
     clock_add_to_group(pac::resources::GPIO, 0);
 
     clock_add_to_group(pac::resources::MBX0, 0);


### PR DESCRIPTION
## Summary

Extract the I2C, DMA, and PDM work from #5 into a focused review branch, keeping the SPI work in #5.

- unify blocking and async I2C pin/resource initialization
- support repeated-start transaction framing and STOP-based timeout recovery
- fix DMA v1 request selection and linked ring-buffer descriptor setup
- enable HPM67 DMA clock resources and configure the PDM RX FIFO threshold
- add blocking and async SSD1306 examples for HPM6750EVKMINI

## Review fixes applied during extraction

- yield while polling async `ADDRHIT` so a missing device does not monopolize the executor
- return `ZeroLengthTransfer` before constructing a zero-length DMA transfer
- apply the configured timeout to DMA transfer and I2C completion waits
- wait for `ADDRHIT` only on frames that actually send an address
- wait for a free bus only before the first blocking transaction frame
- wait for completion on blocking address-only probes
- use the SSD1306-supported 400 kHz I2C mode in both examples
- remove unconditional DMAMUX logging so builds without `defmt` remain valid
- omit the unused example-level `embassy-sync` dependency from #5

## Interaction with #6

The only shared file is `src/dma/dmamux.rs`. Both branches now contain identical final content, and a three-way merge check reports no conflict.

## Validation

Passed:

- `cargo check --target riscv32imac-unknown-none-elf --no-default-features --features hpm6750,rt,embassy,time`
- `cargo check --target riscv32imac-unknown-none-elf --no-default-features --features hpm6e80,rt,embassy,time`
- `cargo check --manifest-path examples/hpm6750evkmini/Cargo.toml --target riscv32imac-unknown-none-elf --bin i2c_oled`
- `cargo check --manifest-path examples/hpm6750evkmini/Cargo.toml --target riscv32imac-unknown-none-elf --bin i2c_oled_async`
- `git diff --check origin/master..HEAD`

An additional build without the `time` feature reaches an existing `src/wdg.rs` import of the optional `embassy_time` dependency; this branch does not modify that file.
