### PR TITLE
fix(build): gate interrupt handlers behind rt feature

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -789,6 +789,7 @@ fn main() {
             };
 
             g.extend(quote! {
+                #[cfg(feature = "rt")]
                 #[hpm_riscv_rt::external_interrupt(hpm_metapac::interrupt::#irq_ident)]
                 fn #irq_ident() {
                     use crate::interrupt::InterruptExt;


### PR DESCRIPTION
The generated external interrupt stubs use the hpm-riscv-rt external_interrupt attribute and hpm-metapac runtime symbols.

Those APIs are only available when the rt feature enables the optional runtime dependency. Keep the generated stubs behind the same feature gate to avoid referencing rt-only symbols without rt.