### PR TITLE
feat(femc): support configurable SDRAM bus geometry

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -354,6 +354,8 @@ fn main() {
         (("femc", "CS1"), quote!(crate::femc::CS1Pin)),
         (("femc", "DM0"), quote!(crate::femc::DM0Pin)),
         (("femc", "DM1"), quote!(crate::femc::DM1Pin)),
+        (("femc", "DM2"), quote!(crate::femc::DM2Pin)),
+        (("femc", "DM3"), quote!(crate::femc::DM3Pin)),
         (("femc", "DQS"), quote!(crate::femc::DQSPin)),
         (("femc", "DQ00"), quote!(crate::femc::DQ00Pin)),
         (("femc", "DQ01"), quote!(crate::femc::DQ01Pin)),

--- a/examples/hpm6750evkmini/src/bin/femc_sdram.rs
+++ b/examples/hpm6750evkmini/src/bin/femc_sdram.rs
@@ -16,7 +16,8 @@ use defmt::info;
 use embassy_time::Delay;
 use embedded_hal::delay::DelayNs;
 use hpm_hal as hal;
-use hpm_hal::femc::{chips::W9812g6jh6, Sdram};
+use hpm_hal::femc::chips::W9812g6jh6;
+use hpm_hal::femc::{ControlPins, Sdram, SdramPins};
 use hpm_hal::gpio::{Level, Output};
 use {defmt_rtt as _};
 
@@ -31,7 +32,7 @@ fn main() -> ! {
     // ========================================================================
     // Type-safe SDRAM initialization (Recommended)
     // ========================================================================
-    // Using Sdram::new_16bit_cs0() with W9812g6jh6 chip definition.
+    // Using Sdram::new_cs0() with W9812g6jh6 chip definition.
     // This approach:
     // - Automatically configures all pins
     // - Uses pre-defined timing from chip datasheet
@@ -40,16 +41,30 @@ fn main() -> ! {
 
     info!("Initializing SDRAM with type-safe API...");
 
-    let sdram = Sdram::new_16bit_cs0(
+    let sdram = Sdram::new_cs0(
         p.FEMC,
-        // Address pins A0-A11
-        p.PC08, p.PC09, p.PC04, p.PC05, p.PC06, p.PC07, p.PC10, p.PC11, p.PC12, p.PC17, p.PC15,
-        p.PC21, // Bank address BA0-BA1
-        p.PC13, p.PC14, // Data pins DQ0-DQ15
-        p.PD08, p.PD05, p.PD00, p.PD01, p.PD02, p.PC27, p.PC28, p.PC29, p.PD04, p.PD03, p.PD07,
-        p.PD06, p.PD10, p.PD09, p.PD13, p.PD12, // Data mask DM0-DM1
-        p.PC30, p.PC31, // Control: DQS, CLK, CKE, RAS, CAS, WE, CS0
-        p.PC16, p.PC26, p.PC25, p.PC18, p.PC23, p.PC24, p.PC19, // Chip configuration
+        SdramPins {
+            // Each tuple position is checked against A00Pin..A11Pin.
+            address: (
+                p.PC08, p.PC09, p.PC04, p.PC05, p.PC06, p.PC07, p.PC10, p.PC11, p.PC12, p.PC17, p.PC15, p.PC21,
+            ),
+            banks: (p.PC13, p.PC14),
+            // Each tuple position is checked against DQ00Pin..DQ15Pin.
+            data: (
+                p.PD08, p.PD05, p.PD00, p.PD01, p.PD02, p.PC27, p.PC28, p.PC29, p.PD04, p.PD03, p.PD07, p.PD06, p.PD10,
+                p.PD09, p.PD13, p.PD12,
+            ),
+            masks: (p.PC30, p.PC31),
+            control: ControlPins {
+                dqs: p.PC16,
+                clk: p.PC26,
+                cke: p.PC25,
+                ras: p.PC18,
+                cas: p.PC23,
+                we: p.PC24,
+                cs: p.PC19,
+            },
+        },
         W9812g6jh6,
     );
 

--- a/src/femc/chips.rs
+++ b/src/femc/chips.rs
@@ -10,7 +10,10 @@
 //! | [`W9812g6jh6`] | 16MB | 16-bit | HPM6750EVKMINI |
 //! | [`W9825g6kh6`] | 32MB | 16-bit | HPM6E00EVK |
 
-use super::{Bank2Sel, BurstLen, CasLatency, ColAddrBits, MemorySize, SdramPortSize};
+use super::geometry::{
+    Address12, Address13, Banks4, Data16, SdramAddressWidth, SdramBankCount, SdramDataWidth,
+};
+use super::{BurstLen, CasLatency, ColAddrBits, MemorySize};
 
 /// Trait for SDRAM chip timing and configuration.
 ///
@@ -21,7 +24,11 @@ use super::{Bank2Sel, BurstLen, CasLatency, ColAddrBits, MemorySize, SdramPortSi
 /// # Example
 ///
 /// ```ignore
-/// use hpm_hal::femc::{SdramChip, chips::W9812g6jh6};
+/// use hpm_hal::femc::{
+///     SdramChip,
+///     chips::W9812g6jh6,
+///     geometry::{Address12, Banks4, Data16},
+/// };
 ///
 /// // Use pre-defined chip
 /// let chip = W9812g6jh6;
@@ -29,24 +36,31 @@ use super::{Bank2Sel, BurstLen, CasLatency, ColAddrBits, MemorySize, SdramPortSi
 /// // Or implement custom chip
 /// struct MyCustomSdram;
 /// impl SdramChip for MyCustomSdram {
+///     type AddressWidth = Address12;
+///     type DataWidth = Data16;
+///     type BankCount = Banks4;
+///
 ///     // ... implement all required methods
 /// }
 /// ```
 pub trait SdramChip {
+    /// Number of physical address pins required by this chip.
+    type AddressWidth: SdramAddressWidth;
+
+    /// Width of the external SDRAM data port.
+    type DataWidth: SdramDataWidth;
+
+    /// Number of banks in the SDRAM.
+    type BankCount: SdramBankCount;
+
     /// Column address bits (8, 9, 10, 11, or 12 bits)
     fn col_addr_bits(&self) -> ColAddrBits;
 
     /// CAS latency (1, 2, or 3 cycles)
     fn cas_latency(&self) -> CasLatency;
 
-    /// Number of banks (2 or 4)
-    fn bank_num(&self) -> Bank2Sel;
-
     /// Memory size
     fn size(&self) -> MemorySize;
-
-    /// Data port size (8, 16, or 32 bits)
-    fn port_size(&self) -> SdramPortSize;
 
     /// Number of rows to refresh (typically 4096 or 8192)
     fn refresh_count(&self) -> u32;
@@ -136,6 +150,10 @@ pub trait SdramChip {
 pub struct W9812g6jh6;
 
 impl SdramChip for W9812g6jh6 {
+    type AddressWidth = Address12;
+    type DataWidth = Data16;
+    type BankCount = Banks4;
+
     fn col_addr_bits(&self) -> ColAddrBits {
         ColAddrBits::_9BIT
     }
@@ -144,16 +162,8 @@ impl SdramChip for W9812g6jh6 {
         CasLatency::_3
     }
 
-    fn bank_num(&self) -> Bank2Sel {
-        Bank2Sel::BANK_NUM_4
-    }
-
     fn size(&self) -> MemorySize {
         MemorySize::_16MB
-    }
-
-    fn port_size(&self) -> SdramPortSize {
-        SdramPortSize::_16BIT
     }
 
     fn refresh_count(&self) -> u32 {
@@ -216,6 +226,10 @@ impl SdramChip for W9812g6jh6 {
 pub struct W9825g6kh6;
 
 impl SdramChip for W9825g6kh6 {
+    type AddressWidth = Address13;
+    type DataWidth = Data16;
+    type BankCount = Banks4;
+
     fn col_addr_bits(&self) -> ColAddrBits {
         ColAddrBits::_9BIT
     }
@@ -224,16 +238,8 @@ impl SdramChip for W9825g6kh6 {
         CasLatency::_3
     }
 
-    fn bank_num(&self) -> Bank2Sel {
-        Bank2Sel::BANK_NUM_4
-    }
-
     fn size(&self) -> MemorySize {
         MemorySize::_32MB
-    }
-
-    fn port_size(&self) -> SdramPortSize {
-        SdramPortSize::_16BIT
     }
 
     fn refresh_count(&self) -> u32 {

--- a/src/femc/geometry.rs
+++ b/src/femc/geometry.rs
@@ -1,0 +1,69 @@
+//! Type-level SDRAM bus geometry.
+//!
+//! These marker types connect an [`SdramChip`](super::SdramChip) definition to
+//! the address, data, and bank pin tuples accepted by
+//! [`Sdram::new_cs0`](super::Sdram::new_cs0). This lets the compiler reject a
+//! pin set whose bus geometry does not match the selected SDRAM chip.
+
+use super::{Bank2Sel, SdramPortSize};
+
+/// Marker for an SDRAM requiring address pins A0-A10.
+pub struct Address11;
+
+/// Marker for an SDRAM requiring address pins A0-A11.
+pub struct Address12;
+
+/// Marker for an SDRAM requiring address pins A0-A12.
+pub struct Address13;
+
+/// Marker for an 8-bit SDRAM data port.
+pub struct Data8;
+
+/// Marker for a 16-bit SDRAM data port.
+pub struct Data16;
+
+/// Marker for a 32-bit SDRAM data port.
+pub struct Data32;
+
+/// Marker for an SDRAM with two banks.
+pub struct Banks2;
+
+/// Marker for an SDRAM with four banks.
+pub struct Banks4;
+
+/// Type-level SDRAM address width.
+pub trait SdramAddressWidth {}
+
+impl SdramAddressWidth for Address11 {}
+impl SdramAddressWidth for Address12 {}
+impl SdramAddressWidth for Address13 {}
+
+/// Type-level SDRAM data port width.
+pub trait SdramDataWidth {
+    const PORT_SIZE: SdramPortSize;
+}
+
+impl SdramDataWidth for Data8 {
+    const PORT_SIZE: SdramPortSize = SdramPortSize::_8BIT;
+}
+
+impl SdramDataWidth for Data16 {
+    const PORT_SIZE: SdramPortSize = SdramPortSize::_16BIT;
+}
+
+impl SdramDataWidth for Data32 {
+    const PORT_SIZE: SdramPortSize = SdramPortSize::_32BIT;
+}
+
+/// Type-level SDRAM bank count.
+pub trait SdramBankCount {
+    const BANK_NUM: Bank2Sel;
+}
+
+impl SdramBankCount for Banks2 {
+    const BANK_NUM: Bank2Sel = Bank2Sel::BANK_NUM_2;
+}
+
+impl SdramBankCount for Banks4 {
+    const BANK_NUM: Bank2Sel = Bank2Sel::BANK_NUM_4;
+}

--- a/src/femc/mod.rs
+++ b/src/femc/mod.rs
@@ -14,23 +14,29 @@
 //! Use the type-safe constructor with compile-time pin checking:
 //!
 //! ```ignore
-//! use hpm_hal::femc::{Femc, chips::W9812g6jh6};
+//! use hpm_hal::femc::{
+//!     ControlPins, Sdram, SdramPins,
+//!     chips::W9812g6jh6,
+//! };
 //!
-//! let sdram = Femc::sdram_a12bits_d16bits_4banks_cs0(
+//! let sdram = Sdram::new_cs0(
 //!     p.FEMC,
-//!     // Address pins A0-A11
-//!     p.PC08, p.PC09, p.PC04, p.PC05, p.PC06, p.PC07,
-//!     p.PC10, p.PC11, p.PC12, p.PC17, p.PC15, p.PC21,
-//!     // Bank address BA0-BA1
-//!     p.PC13, p.PC14,
-//!     // Data DQ0-DQ15
-//!     p.PD08, p.PD05, p.PD00, p.PD01, p.PD02, p.PC27, p.PC28, p.PC29,
-//!     p.PD04, p.PD03, p.PD07, p.PD06, p.PD10, p.PD09, p.PD13, p.PD12,
-//!     // Data mask DM0-DM1
-//!     p.PC30, p.PC31,
-//!     // Control: DQS, CLK, CKE, RAS, CAS, WE, CS0
-//!     p.PC16, p.PC26, p.PC25, p.PC18, p.PC23, p.PC24, p.PC19,
-//!     // Chip configuration
+//!     SdramPins {
+//!         address: (
+//!             p.PC08, p.PC09, p.PC04, p.PC05, p.PC06, p.PC07,
+//!             p.PC10, p.PC11, p.PC12, p.PC17, p.PC15, p.PC21,
+//!         ),
+//!         banks: (p.PC13, p.PC14),
+//!         data: (
+//!             p.PD08, p.PD05, p.PD00, p.PD01, p.PD02, p.PC27, p.PC28, p.PC29,
+//!             p.PD04, p.PD03, p.PD07, p.PD06, p.PD10, p.PD09, p.PD13, p.PD12,
+//!         ),
+//!         masks: (p.PC30, p.PC31),
+//!         control: ControlPins {
+//!             dqs: p.PC16, clk: p.PC26, cke: p.PC25, ras: p.PC18,
+//!             cas: p.PC23, we: p.PC24, cs: p.PC19,
+//!         },
+//!     },
 //!     W9812g6jh6,
 //! );
 //!
@@ -62,19 +68,24 @@
 //! ```
 
 pub mod chips;
+pub mod geometry;
 
-use core::marker::PhantomData;
-use core::mem;
+use core::{marker::PhantomData, mem};
 
 use embassy_hal_internal::{Peri, PeripheralType};
 use embedded_hal::delay::DelayNs;
+
+use crate::gpio::Pin;
+
+use geometry::{
+    Address11, Address12, Address13, Banks2, Banks4, Data8, Data16, Data32, SdramAddressWidth, SdramBankCount,
+    SdramDataWidth,
+};
 
 pub use chips::SdramChip;
 pub use hpm_metapac::femc::vals::{
     Bank2Sel, BurstLen, CasLatency, ColAddrBits, DataSize, Dqs, MemorySize, SdramCmd, SdramPortSize,
 };
-
-use crate::gpio::Pin;
 
 const HPM_FEMC_DRV_RETRY_COUNT: usize = 5000;
 const FEMC_CMD_KEY: u16 = 0x5AA5;
@@ -251,9 +262,9 @@ impl FemcSdramConfig {
             col_addr_bits: chip.col_addr_bits(),
             cas_latency: chip.cas_latency(),
             cs,
-            bank_num: chip.bank_num(),
+            bank_num: C::BankCount::BANK_NUM,
             prescaler: chip.prescaler(),
-            port_size: chip.port_size(),
+            port_size: C::DataWidth::PORT_SIZE,
             burst_len: chip.burst_len(),
             cke_off_in_ns: chip.t_cke_off(),
             act_to_precharge_in_ns: chip.t_ras(),
@@ -729,6 +740,26 @@ pub struct Sdram<'d, T: Instance, C: SdramChip> {
 }
 
 impl<'d, T: Instance + PeripheralType, C: SdramChip> Sdram<'d, T, C> {
+    /// Create an SDRAM controller on CS0 from a type-checked pin set.
+    ///
+    /// The pin set's address width, data width, and bank count must match the
+    /// geometry declared by `C`. Each tuple position is also checked against
+    /// its individual FEMC pin trait.
+    pub fn new_cs0<P>(_peri: Peri<'d, T>, pins: P, chip: C) -> Self
+    where
+        P: SdramPinSet<T, AddressWidth = C::AddressWidth, DataWidth = C::DataWidth, BankCount = C::BankCount>,
+    {
+        T::add_resource_group(0);
+        pins.configure();
+
+        Self {
+            _peri: PhantomData,
+            base_address: chip.base_address(),
+            chip,
+            cs: 0,
+        }
+    }
+
     /// Initialize the SDRAM controller and memory.
     ///
     /// This method performs the full SDRAM initialization sequence:
@@ -764,7 +795,8 @@ impl<'d, T: Instance + PeripheralType, C: SdramChip> Sdram<'d, T, C> {
         // Wait for SDRAM power-up
         delay.delay_us(200);
 
-        let _ = femc.configure_sdram(clk_hz, config);
+        femc.configure_sdram(clk_hz, config)
+            .expect("failed to configure FEMC SDRAM");
 
         self.base_address as *mut u32
     }
@@ -807,19 +839,261 @@ fn memory_size_to_bytes(size: MemorySize) -> usize {
     }
 }
 
-// ============================================================================
-// Type-safe constructors
-// ============================================================================
-
-/// Configure a pin for FEMC alternate function.
+/// Complete pin set for an SDRAM device.
 ///
-/// This function sets the pin to the correct alternate function for FEMC.
+/// Address, bank, data, and mask pins are tuples ordered by their FEMC signal
+/// number. Each tuple position is checked against its individual pin trait.
+pub struct SdramPins<A, B, D, M, C> {
+    pub address: A,
+    pub banks: B,
+    pub data: D,
+    pub masks: M,
+    pub control: C,
+}
+
+/// Control pins shared by every SDRAM configuration on a chip-select line.
+pub struct ControlPins<DQS, CLK, CKE, RAS, CAS, WE, CS> {
+    pub dqs: DQS,
+    pub clk: CLK,
+    pub cke: CKE,
+    pub ras: RAS,
+    pub cas: CAS,
+    pub we: WE,
+    pub cs: CS,
+}
+
+/// Compile-time description of a valid SDRAM pin set.
+///
+/// This trait is public only because it appears in [`Sdram::new_cs0`]'s
+/// generic bounds. It is sealed and cannot be implemented downstream.
+#[doc(hidden)]
+pub trait SdramPinSet<T: Instance>: sealed::SdramPinSet<T> {
+    type AddressWidth: SdramAddressWidth;
+    type DataWidth: SdramDataWidth;
+    type BankCount: SdramBankCount;
+
+    fn configure(self);
+}
+
+#[doc(hidden)]
+pub trait AddressPinGroup<T: Instance>: sealed::AddressPinGroup<T> {
+    type Width: SdramAddressWidth;
+
+    fn configure(self);
+}
+
+#[doc(hidden)]
+pub trait BankPinGroup<T: Instance>: sealed::BankPinGroup<T> {
+    type Count: SdramBankCount;
+
+    fn configure(self);
+}
+
+#[doc(hidden)]
+pub trait DataPinGroup<T: Instance>: sealed::DataPinGroup<T> {
+    type Width: SdramDataWidth;
+
+    fn configure(self);
+}
+
+#[doc(hidden)]
+pub trait DataMaskPinGroup<T: Instance>: sealed::DataMaskPinGroup<T> {
+    type Width: SdramDataWidth;
+
+    fn configure(self);
+}
+
+#[doc(hidden)]
+pub trait Cs0ControlPinGroup<T: Instance>: sealed::Cs0ControlPinGroup<T> {
+    fn configure(self);
+}
+
+// All public extension points in this module are sealed here. `Instance`
+// restricts FEMC implementations to generated peripherals, while the pin-set
+// traits prevent downstream code from claiming a geometry that did not pass
+// the per-signal pin checks below.
+mod sealed {
+    pub trait Instance: crate::sysctl::ClockPeripheral {
+        const REGS: crate::pac::femc::Femc;
+    }
+
+    pub trait SdramPinSet<T> {}
+    pub trait AddressPinGroup<T> {}
+    pub trait BankPinGroup<T> {}
+    pub trait DataPinGroup<T> {}
+    pub trait DataMaskPinGroup<T> {}
+    pub trait Cs0ControlPinGroup<T> {}
+}
+
 #[inline]
-fn configure_femc_pin<P: Pin>(pin: &P, alt_num: u8, loop_back: bool) {
+fn configure_pin<P: Pin>(pin: &P, alt_num: u8, loop_back: bool) {
     pin.ioc_pad().func_ctl().write(|w| {
         w.set_alt_select(alt_num);
         w.set_loop_back(loop_back);
     });
+}
+
+macro_rules! impl_pin_group {
+    ($group_trait:ident, $associated:ident = $width:ty; $(($pin_ty:ident, $pin:ident, $pin_trait:ident)),+ $(,)?) => {
+        impl<'d, T, $($pin_ty),+> sealed::$group_trait<T> for ($(Peri<'d, $pin_ty>,)+)
+        where
+            T: Instance,
+            $($pin_ty: $pin_trait<T>,)+
+        {}
+
+        impl<'d, T, $($pin_ty),+> $group_trait<T> for ($(Peri<'d, $pin_ty>,)+)
+        where
+            T: Instance,
+            $($pin_ty: $pin_trait<T>,)+
+        {
+            type $associated = $width;
+
+            fn configure(self) {
+                let ($($pin,)+) = self;
+                $(configure_pin(&*$pin, $pin.alt_num(), false);)+
+            }
+        }
+    };
+}
+
+impl_pin_group!(AddressPinGroup, Width = Address11;
+    (A0, a0, A00Pin), (A1, a1, A01Pin), (A2, a2, A02Pin),
+    (A3, a3, A03Pin), (A4, a4, A04Pin), (A5, a5, A05Pin),
+    (A6, a6, A06Pin), (A7, a7, A07Pin), (A8, a8, A08Pin),
+    (A9, a9, A09Pin), (A10, a10, A10Pin),
+);
+
+impl_pin_group!(AddressPinGroup, Width = Address12;
+    (A0, a0, A00Pin), (A1, a1, A01Pin), (A2, a2, A02Pin),
+    (A3, a3, A03Pin), (A4, a4, A04Pin), (A5, a5, A05Pin),
+    (A6, a6, A06Pin), (A7, a7, A07Pin), (A8, a8, A08Pin),
+    (A9, a9, A09Pin), (A10, a10, A10Pin), (A11, a11, A11Pin),
+);
+
+impl_pin_group!(AddressPinGroup, Width = Address13;
+    (A0, a0, A00Pin), (A1, a1, A01Pin), (A2, a2, A02Pin),
+    (A3, a3, A03Pin), (A4, a4, A04Pin), (A5, a5, A05Pin),
+    (A6, a6, A06Pin), (A7, a7, A07Pin), (A8, a8, A08Pin),
+    (A9, a9, A09Pin), (A10, a10, A10Pin), (A11, a11, A11Pin),
+    (A12, a12, A12Pin),
+);
+
+impl_pin_group!(BankPinGroup, Count = Banks2; (BA0, ba0, BA0Pin));
+impl_pin_group!(BankPinGroup, Count = Banks4; (BA0, ba0, BA0Pin), (BA1, ba1, BA1Pin));
+
+impl_pin_group!(DataPinGroup, Width = Data8;
+    (D0, d0, DQ00Pin), (D1, d1, DQ01Pin), (D2, d2, DQ02Pin), (D3, d3, DQ03Pin),
+    (D4, d4, DQ04Pin), (D5, d5, DQ05Pin), (D6, d6, DQ06Pin), (D7, d7, DQ07Pin),
+);
+
+impl_pin_group!(DataPinGroup, Width = Data16;
+    (D0, d0, DQ00Pin), (D1, d1, DQ01Pin), (D2, d2, DQ02Pin), (D3, d3, DQ03Pin),
+    (D4, d4, DQ04Pin), (D5, d5, DQ05Pin), (D6, d6, DQ06Pin), (D7, d7, DQ07Pin),
+    (D8, d8, DQ08Pin), (D9, d9, DQ09Pin), (D10, d10, DQ10Pin), (D11, d11, DQ11Pin),
+    (D12, d12, DQ12Pin), (D13, d13, DQ13Pin), (D14, d14, DQ14Pin), (D15, d15, DQ15Pin),
+);
+
+impl_pin_group!(DataPinGroup, Width = Data32;
+    (D0, d0, DQ00Pin), (D1, d1, DQ01Pin), (D2, d2, DQ02Pin), (D3, d3, DQ03Pin),
+    (D4, d4, DQ04Pin), (D5, d5, DQ05Pin), (D6, d6, DQ06Pin), (D7, d7, DQ07Pin),
+    (D8, d8, DQ08Pin), (D9, d9, DQ09Pin), (D10, d10, DQ10Pin), (D11, d11, DQ11Pin),
+    (D12, d12, DQ12Pin), (D13, d13, DQ13Pin), (D14, d14, DQ14Pin), (D15, d15, DQ15Pin),
+    (D16, d16, DQ16Pin), (D17, d17, DQ17Pin), (D18, d18, DQ18Pin), (D19, d19, DQ19Pin),
+    (D20, d20, DQ20Pin), (D21, d21, DQ21Pin), (D22, d22, DQ22Pin), (D23, d23, DQ23Pin),
+    (D24, d24, DQ24Pin), (D25, d25, DQ25Pin), (D26, d26, DQ26Pin), (D27, d27, DQ27Pin),
+    (D28, d28, DQ28Pin), (D29, d29, DQ29Pin), (D30, d30, DQ30Pin), (D31, d31, DQ31Pin),
+);
+
+impl_pin_group!(DataMaskPinGroup, Width = Data8; (DM0, dm0, DM0Pin));
+impl_pin_group!(DataMaskPinGroup, Width = Data16; (DM0, dm0, DM0Pin), (DM1, dm1, DM1Pin));
+impl_pin_group!(DataMaskPinGroup, Width = Data32;
+    (DM0, dm0, DM0Pin), (DM1, dm1, DM1Pin), (DM2, dm2, DM2Pin), (DM3, dm3, DM3Pin),
+);
+
+impl<'d, T, DQS, CLK, CKE, RAS, CAS, WE, CS> Cs0ControlPinGroup<T>
+    for ControlPins<
+        Peri<'d, DQS>,
+        Peri<'d, CLK>,
+        Peri<'d, CKE>,
+        Peri<'d, RAS>,
+        Peri<'d, CAS>,
+        Peri<'d, WE>,
+        Peri<'d, CS>,
+    >
+where
+    T: Instance,
+    DQS: DQSPin<T>,
+    CLK: CLKPin<T>,
+    CKE: CKEPin<T>,
+    RAS: RASPin<T>,
+    CAS: CASPin<T>,
+    WE: WEPin<T>,
+    CS: CS0Pin<T>,
+{
+    fn configure(self) {
+        configure_pin(&*self.dqs, self.dqs.alt_num(), true);
+        configure_pin(&*self.clk, self.clk.alt_num(), false);
+        configure_pin(&*self.cke, self.cke.alt_num(), false);
+        configure_pin(&*self.ras, self.ras.alt_num(), false);
+        configure_pin(&*self.cas, self.cas.alt_num(), false);
+        configure_pin(&*self.we, self.we.alt_num(), false);
+        configure_pin(&*self.cs, self.cs.alt_num(), false);
+    }
+}
+
+impl<'d, T, DQS, CLK, CKE, RAS, CAS, WE, CS> sealed::Cs0ControlPinGroup<T>
+    for ControlPins<
+        Peri<'d, DQS>,
+        Peri<'d, CLK>,
+        Peri<'d, CKE>,
+        Peri<'d, RAS>,
+        Peri<'d, CAS>,
+        Peri<'d, WE>,
+        Peri<'d, CS>,
+    >
+where
+    T: Instance,
+    DQS: DQSPin<T>,
+    CLK: CLKPin<T>,
+    CKE: CKEPin<T>,
+    RAS: RASPin<T>,
+    CAS: CASPin<T>,
+    WE: WEPin<T>,
+    CS: CS0Pin<T>,
+{
+}
+
+impl<T, A, B, D, M, C> SdramPinSet<T> for SdramPins<A, B, D, M, C>
+where
+    T: Instance,
+    A: AddressPinGroup<T>,
+    B: BankPinGroup<T>,
+    D: DataPinGroup<T>,
+    M: DataMaskPinGroup<T, Width = D::Width>,
+    C: Cs0ControlPinGroup<T>,
+{
+    type AddressWidth = A::Width;
+    type DataWidth = D::Width;
+    type BankCount = B::Count;
+
+    fn configure(self) {
+        self.address.configure();
+        self.banks.configure();
+        self.data.configure();
+        self.masks.configure();
+        self.control.configure();
+    }
+}
+
+impl<T, A, B, D, M, C> sealed::SdramPinSet<T> for SdramPins<A, B, D, M, C>
+where
+    T: Instance,
+    A: AddressPinGroup<T>,
+    B: BankPinGroup<T>,
+    D: DataPinGroup<T>,
+    M: DataMaskPinGroup<T, Width = D::Width>,
+    C: Cs0ControlPinGroup<T>,
+{
 }
 
 impl<'d, T: Instance + PeripheralType, C: SdramChip> Sdram<'d, T, C> {
@@ -863,6 +1137,7 @@ impl<'d, T: Instance + PeripheralType, C: SdramChip> Sdram<'d, T, C> {
     /// );
     /// let ram_ptr = sdram.init(&mut Delay);
     /// ```
+    #[deprecated(note = "Use Sdram::new_cs0 with SdramPins instead")]
     #[allow(clippy::too_many_arguments)]
     pub fn new_16bit_cs0(
         _peri: Peri<'d, T>,
@@ -912,67 +1187,31 @@ impl<'d, T: Instance + PeripheralType, C: SdramChip> Sdram<'d, T, C> {
         cs: Peri<'d, impl CS0Pin<T>>,
         // Chip configuration
         chip: C,
-    ) -> Sdram<'d, T, C> {
-        // Add to resource group
-        T::add_resource_group(0);
-
-        // Configure address pins
-        configure_femc_pin(&*a0, a0.alt_num(), false);
-        configure_femc_pin(&*a1, a1.alt_num(), false);
-        configure_femc_pin(&*a2, a2.alt_num(), false);
-        configure_femc_pin(&*a3, a3.alt_num(), false);
-        configure_femc_pin(&*a4, a4.alt_num(), false);
-        configure_femc_pin(&*a5, a5.alt_num(), false);
-        configure_femc_pin(&*a6, a6.alt_num(), false);
-        configure_femc_pin(&*a7, a7.alt_num(), false);
-        configure_femc_pin(&*a8, a8.alt_num(), false);
-        configure_femc_pin(&*a9, a9.alt_num(), false);
-        configure_femc_pin(&*a10, a10.alt_num(), false);
-        configure_femc_pin(&*a11, a11.alt_num(), false);
-
-        // Configure bank address pins
-        configure_femc_pin(&*ba0, ba0.alt_num(), false);
-        configure_femc_pin(&*ba1, ba1.alt_num(), false);
-
-        // Configure data pins
-        configure_femc_pin(&*dq0, dq0.alt_num(), false);
-        configure_femc_pin(&*dq1, dq1.alt_num(), false);
-        configure_femc_pin(&*dq2, dq2.alt_num(), false);
-        configure_femc_pin(&*dq3, dq3.alt_num(), false);
-        configure_femc_pin(&*dq4, dq4.alt_num(), false);
-        configure_femc_pin(&*dq5, dq5.alt_num(), false);
-        configure_femc_pin(&*dq6, dq6.alt_num(), false);
-        configure_femc_pin(&*dq7, dq7.alt_num(), false);
-        configure_femc_pin(&*dq8, dq8.alt_num(), false);
-        configure_femc_pin(&*dq9, dq9.alt_num(), false);
-        configure_femc_pin(&*dq10, dq10.alt_num(), false);
-        configure_femc_pin(&*dq11, dq11.alt_num(), false);
-        configure_femc_pin(&*dq12, dq12.alt_num(), false);
-        configure_femc_pin(&*dq13, dq13.alt_num(), false);
-        configure_femc_pin(&*dq14, dq14.alt_num(), false);
-        configure_femc_pin(&*dq15, dq15.alt_num(), false);
-
-        // Configure data mask pins
-        configure_femc_pin(&*dm0, dm0.alt_num(), false);
-        configure_femc_pin(&*dm1, dm1.alt_num(), false);
-
-        // Configure control pins
-        // DQS requires loop_back = true for SDRAM (C SDK behavior)
-        configure_femc_pin(&*dqs, dqs.alt_num(), true);
-        configure_femc_pin(&*clk, clk.alt_num(), false);
-        configure_femc_pin(&*cke, cke.alt_num(), false);
-        configure_femc_pin(&*ras, ras.alt_num(), false);
-        configure_femc_pin(&*cas, cas.alt_num(), false);
-        configure_femc_pin(&*we, we.alt_num(), false);
-        configure_femc_pin(&*cs, cs.alt_num(), false);
-
-        let base_address = chip.base_address();
-        Sdram {
-            _peri: PhantomData,
+    ) -> Sdram<'d, T, C>
+    where
+        C: SdramChip<AddressWidth = Address12, DataWidth = Data16, BankCount = Banks4>,
+    {
+        Self::new_cs0(
+            _peri,
+            SdramPins {
+                address: (a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11),
+                banks: (ba0, ba1),
+                data: (
+                    dq0, dq1, dq2, dq3, dq4, dq5, dq6, dq7, dq8, dq9, dq10, dq11, dq12, dq13, dq14, dq15,
+                ),
+                masks: (dm0, dm1),
+                control: ControlPins {
+                    dqs,
+                    clk,
+                    cke,
+                    ras,
+                    cas,
+                    we,
+                    cs,
+                },
+            },
             chip,
-            base_address,
-            cs: 0,
-        }
+        )
     }
 }
 
@@ -1005,17 +1244,13 @@ pub enum Error {
 // Instance trait
 // ============================================================================
 
-trait SealedInstance: crate::sysctl::ClockPeripheral {
-    const REGS: crate::pac::femc::Femc;
-}
-
 /// FEMC instance trait.
 #[allow(private_bounds)]
-pub trait Instance: SealedInstance + 'static {}
+pub trait Instance: sealed::Instance + 'static {}
 
 foreach_peripheral!(
     (femc, $inst:ident) => {
-        impl crate::femc::SealedInstance for crate::peripherals::$inst {
+        impl crate::femc::sealed::Instance for crate::peripherals::$inst {
             const REGS: crate::pac::femc::Femc = crate::pac::$inst;
         }
         impl crate::femc::Instance for crate::peripherals::$inst {}
@@ -1052,6 +1287,8 @@ pin_trait!(CS1Pin, Instance); // NCE for SRAM
 
 pin_trait!(DM0Pin, Instance);
 pin_trait!(DM1Pin, Instance);
+pin_trait!(DM2Pin, Instance);
+pin_trait!(DM3Pin, Instance);
 
 pin_trait!(DQSPin, Instance);
 


### PR DESCRIPTION
Add type-level address, data, and bank markers so SDRAM pin sets can support 11-13 address bits and 8-, 16-, or 32-bit data buses while retaining per-pin trait checks.

Deprecate new_16bit_cs0 in favor of Sdram::new_cs0 and update the HPM6750 example. Existing callers remain source-compatible.

Signed-off-by: tfx2001 <tfx2001@outlook.com>